### PR TITLE
Fix install include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,7 @@ catkin_package(
     DEPENDS
     )
 
-include_directories(
-    include
-    ${catkin_INCLUDE_DIRS}
-    )
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,20 +2,22 @@ cmake_minimum_required(VERSION 2.8.3)
 project(camera_base)
 
 find_package(catkin REQUIRED COMPONENTS
-    roscpp
+  roscpp
+  camera_info_manager
+  diagnostic_updater
+  dynamic_reconfigure
+  image_transport
+  sensor_msgs)
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS
     camera_info_manager
     diagnostic_updater
     dynamic_reconfigure
     image_transport
-    sensor_msgs
-    )
-
-catkin_package(
-    INCLUDE_DIRS include
-    LIBRARIES
-    CATKIN_DEPENDS camera_info_manager diagnostic_updater dynamic_reconfigure image_transport roscpp sensor_msgs
-    DEPENDS
-    )
+    roscpp
+    sensor_msgs)
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}


### PR DESCRIPTION
The only purpose of this package is to provide the include headers to others, and it does NOT install them.

This PR fixes that.

Who can merge this? @guillaumeautran @mikepurvis 
Or just give me access to merge here :wink: 

I've also homogenize/change the rest of the `CMakeLists.txt` file: style and removal of not needed stuff like `include_directories`, `LIBRARIES` (empty), `DEPENDS` (empty).